### PR TITLE
README.md:9 omit package name from $ npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Connect your website to your robot!
 
 ## Install
 
-```bash
-npm install react-ros
+```
+$ npm install 
 ```
 
 ## Usage


### PR DESCRIPTION
formerly:
$ npm install _react-ros_
```
npm ERR! code ENOSELF
npm ERR! Refusing to install package with name "react-ros" under a package
npm ERR! also called "react-ros". Did you name your project the same
npm ERR! as the dependency you're installing?
npm ERR!
npm ERR! For more information, see:
npm ERR! https://docs.npmjs.com/cli/install#limitations-of-npms-install-algorithm
```